### PR TITLE
Configure social and email login methods

### DIFF
--- a/examples/react-reown-authentication/src/main.tsx
+++ b/examples/react-reown-authentication/src/main.tsx
@@ -22,6 +22,10 @@ createAppKit({
   },
   projectId,
   themeMode: 'light',
+  // Example: force EOA for social/email logins
+  disableAuthSmartAccounts: true,
+  // To default to Smart Account instead (if you enable it later), set:
+  // defaultAccountTypes: { eip155: 'smartAccount' },
   siwx: new ReownAuthentication()
 })
 

--- a/packages/adapters/ethers/src/client.ts
+++ b/packages/adapters/ethers/src/client.ts
@@ -12,7 +12,8 @@ import {
   type Provider,
   SIWXUtil,
   StorageUtil,
-  getPreferredAccountType
+  getPreferredAccountType,
+  OptionsController
 } from '@reown/appkit-controllers'
 import { ConstantsUtil, HelpersUtil, PresetsUtil } from '@reown/appkit-utils'
 import { ProviderUtil } from '@reown/appkit-utils'
@@ -459,7 +460,8 @@ export class EthersAdapter extends AdapterBlueprint {
           chainNamespace: CommonConstantsUtil.CHAIN.EVM,
           chainId,
           socialUri,
-          preferredAccountType: getPreferredAccountType('eip155')
+          preferredAccountType:
+            (OptionsController.state.disableAuthSmartAccounts ? 'eoa' : getPreferredAccountType('eip155'))
         })
 
       const caipNetwork = this.getCaipNetworks().find(n => n.id.toString() === chainId?.toString())
@@ -546,7 +548,8 @@ export class EthersAdapter extends AdapterBlueprint {
         authConnector: connector.provider as unknown as W3mFrameProvider,
         chainNamespace: CommonConstantsUtil.CHAIN.EVM,
         chainId,
-        preferredAccountType: getPreferredAccountType('eip155')
+        preferredAccountType:
+          (OptionsController.state.disableAuthSmartAccounts ? 'eoa' : getPreferredAccountType('eip155'))
       })
     }
   }

--- a/packages/adapters/ethers5/src/client.ts
+++ b/packages/adapters/ethers5/src/client.ts
@@ -13,7 +13,8 @@ import {
   type Provider,
   SIWXUtil,
   StorageUtil,
-  getPreferredAccountType
+  getPreferredAccountType,
+  OptionsController
 } from '@reown/appkit-controllers'
 import { ConstantsUtil, HelpersUtil, PresetsUtil } from '@reown/appkit-utils'
 import { ProviderUtil } from '@reown/appkit-utils'
@@ -462,7 +463,8 @@ export class Ethers5Adapter extends AdapterBlueprint {
           chainNamespace: CommonConstantsUtil.CHAIN.EVM,
           chainId,
           socialUri,
-          preferredAccountType: getPreferredAccountType('eip155')
+          preferredAccountType:
+            (OptionsController.state.disableAuthSmartAccounts ? 'eoa' : getPreferredAccountType('eip155'))
         })
 
       const caipNetwork = this.getCaipNetworks().find(n => n.id.toString() === chainId?.toString())
@@ -598,7 +600,8 @@ export class Ethers5Adapter extends AdapterBlueprint {
         authConnector: connector.provider as unknown as W3mFrameProvider,
         chainNamespace: CommonConstantsUtil.CHAIN.EVM,
         chainId,
-        preferredAccountType: getPreferredAccountType('eip155')
+        preferredAccountType:
+          (OptionsController.state.disableAuthSmartAccounts ? 'eoa' : getPreferredAccountType('eip155'))
       })
     }
   }

--- a/packages/adapters/wagmi/src/connectors/AuthConnector.ts
+++ b/packages/adapters/wagmi/src/connectors/AuthConnector.ts
@@ -15,7 +15,8 @@ import {
   ConnectorController,
   SIWXUtil,
   getActiveCaipNetwork,
-  getPreferredAccountType
+  getPreferredAccountType,
+  OptionsController
 } from '@reown/appkit-controllers'
 import { ErrorUtil } from '@reown/appkit-utils'
 import { W3mFrameProvider } from '@reown/appkit-wallet'
@@ -100,7 +101,9 @@ export function authConnector(parameters: AuthParameters) {
       }
     }
 
-    const preferredAccountType = getPreferredAccountType('eip155')
+    const preferredAccountType = OptionsController.state.disableAuthSmartAccounts
+      ? 'eoa'
+      : getPreferredAccountType('eip155')
 
     const {
       address,

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -328,6 +328,9 @@ export abstract class AppKitBaseClient {
     OptionsController.setUniversalProviderConfigOverride(options.universalProviderConfigOverride)
     OptionsController.setPreferUniversalLinks(options.experimental_preferUniversalLinks)
 
+    // New: Disable smart accounts for AUTH flows if requested
+    OptionsController.setDisableAuthSmartAccounts(options.disableAuthSmartAccounts)
+
     // Save option in controller
     OptionsController.setDefaultAccountTypes(options.defaultAccountTypes)
 

--- a/packages/appkit/src/client/appkit.ts
+++ b/packages/appkit/src/client/appkit.ts
@@ -101,10 +101,13 @@ export class AppKit extends AppKitBaseClient {
 
     const defaultAccountType = OptionsController.state.defaultAccountTypes[namespace]
     const currentAccountType = getPreferredAccountType(namespace)
-    const preferredAccountType =
+    const resolvedPreferred =
       (user.preferredAccountType as W3mFrameTypes.AccountType) ||
       currentAccountType ||
       defaultAccountType
+    const preferredAccountType = OptionsController.state.disableAuthSmartAccounts
+      ? (W3mFrameRpcConstants.ACCOUNT_TYPES.EOA as W3mFrameTypes.AccountType)
+      : resolvedPreferred
 
     /*
      * This covers the case where user switches back from a smart account supported

--- a/packages/appkit/src/utils/TypesUtil.ts
+++ b/packages/appkit/src/utils/TypesUtil.ts
@@ -103,6 +103,11 @@ export type AppKitOptions = {
    * @default "{ bip122: 'payment', eip155: 'smartAccount', polkadot: 'eoa', solana: 'eoa' }"
    */
   defaultAccountTypes?: Partial<OptionsControllerState['defaultAccountTypes']>
+  /**
+   * Disable smart accounts when using social/email (Auth) login. Forces EOA for AUTH flows.
+   * @default false
+   */
+  disableAuthSmartAccounts?: boolean
 } & Omit<OptionsControllerState, 'defaultAccountTypes'>
 
 export interface FeatureConfigItem {

--- a/packages/controllers/src/controllers/ChainController.ts
+++ b/packages/controllers/src/controllers/ChainController.ts
@@ -611,6 +611,11 @@ const controller = {
       return false
     }
 
+    // If smart accounts are disabled for Auth flows, treat as disabled
+    if (OptionsController.state.disableAuthSmartAccounts) {
+      return false
+    }
+
     const smartAccountEnabledNetworks = ChainController.getNetworkProp(
       'smartAccountEnabledNetworks',
       activeChain

--- a/packages/controllers/src/controllers/OptionsController.ts
+++ b/packages/controllers/src/controllers/OptionsController.ts
@@ -194,6 +194,11 @@ export interface OptionsControllerStatePublic {
    * @default true
    */
   enableNetworkSwitch?: boolean
+  /**
+   * Disable smart accounts when using social/email (Auth) login. Forces EOA for AUTH flows.
+   * @default false
+   */
+  disableAuthSmartAccounts?: boolean
 }
 
 export interface OptionsControllerStateInternal {
@@ -216,7 +221,8 @@ const state = proxy<OptionsControllerState>({
   defaultAccountTypes: ConstantsUtil.DEFAULT_ACCOUNT_TYPES,
   enableNetworkSwitch: true,
   experimental_preferUniversalLinks: false,
-  remoteFeatures: {}
+  remoteFeatures: {},
+  disableAuthSmartAccounts: false
 })
 
 // -- Controller ---------------------------------------- //
@@ -432,6 +438,12 @@ export const OptionsController = {
         state.defaultAccountTypes[namespace] = accountType
       }
     })
+  },
+
+  setDisableAuthSmartAccounts(
+    disableAuthSmartAccounts: OptionsControllerState['disableAuthSmartAccounts']
+  ) {
+    state.disableAuthSmartAccounts = Boolean(disableAuthSmartAccounts)
   },
 
   setUniversalProviderConfigOverride(

--- a/packages/controllers/src/utils/ConstantsUtil.ts
+++ b/packages/controllers/src/utils/ConstantsUtil.ts
@@ -267,7 +267,7 @@ export const ConstantsUtil = {
 
   DEFAULT_ACCOUNT_TYPES: {
     bip122: 'payment',
-    eip155: 'smartAccount',
+    eip155: 'eoa',
     polkadot: 'eoa',
     solana: 'eoa'
   } as const satisfies PreferredAccountTypes,


### PR DESCRIPTION
# Description

This PR disables smart accounts by default for social/email (Auth) logins, ensuring EOA is used. It introduces a new `disableAuthSmartAccounts` option to explicitly force EOA for Auth flows. Additionally, the default `eip155` account type is now set to EOA, and the `defaultAccountTypes` option can be used to configure the preferred account type when smart accounts are enabled for Auth.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

# Showcase (Optional)

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link

---
<a href="https://cursor.com/background-agent?bcId=bc-17f7e259-fe41-4fa5-9cf8-a149d2cc0a37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-17f7e259-fe41-4fa5-9cf8-a149d2cc0a37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

